### PR TITLE
Refactor SDR configs to use `omitempty` and clean up strings usage

### DIFF
--- a/internal/sdr/hackrf/config.go
+++ b/internal/sdr/hackrf/config.go
@@ -4,15 +4,13 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
-	"strings"
 )
 
 const (
-	MinNumSamples = 8192
-	MaxLNAGain    = 40
-	MaxVGAGain    = 62
-	LNAGainStep   = 8
-	VGAGainStep   = 2
+	MaxLNAGain  = 40
+	MaxVGAGain  = 62
+	LNAGainStep = 8
+	VGAGainStep = 2
 )
 
 // Usage examples from man page:
@@ -37,14 +35,14 @@ type Config struct {
 	FrequencyEnd   int64 `yaml:"frequencyEnd" json:"frequencyEnd"`     // -f freq_max Frequency range end in MHz
 
 	// Important but Optional (have reasonable defaults)
-	LNAGain  *int  `yaml:"lnaGain" json:"lnaGain"`   // -l gain_db LNA (IF) gain, 0-40dB, 8dB steps
-	VGAGain  *int  `yaml:"vgaGain" json:"vgaGain"`   // -g gain_db VGA (baseband) gain, 0-62dB, 2dB steps
-	BinWidth int64 `yaml:"binWidth" json:"binWidth"` // -w bin_width FFT bin width (frequency resolution) in Hz
+	LNAGain  *int  `yaml:"lnaGain" json:"lnaGain,omitempty"`   // -l gain_db LNA (IF) gain, 0-40dB, 8dB steps
+	VGAGain  *int  `yaml:"vgaGain" json:"vgaGain,omitempty"`   // -g gain_db VGA (baseband) gain, 0-62dB, 2dB steps
+	BinWidth int64 `yaml:"binWidth" json:"binWidth,omitempty"` // -w bin_width FFT bin width (frequency resolution) in Hz
 
 	// Optional - Advanced Configuration
-	SerialNumber string `yaml:"serialNumber" json:"serialNumber"` // -d serial_number Serial number of desired HackRF
-	EnableAmp    bool   `yaml:"enableAmp" json:"enableAmp"`       // -a amp_enable RX RF amplifier 1=Enable, 0=Disable
-	AntennaPower bool   `yaml:"antennaPower" json:"antennaPower"` // -p antenna_enable Antenna port power, 1=Enable, 0=Disable
+	SerialNumber string `yaml:"serialNumber" json:"serialNumber,omitempty"` // -d serial_number Serial number of desired HackRF
+	EnableAmp    bool   `yaml:"enableAmp" json:"enableAmp,omitempty"`       // -a amp_enable RX RF amplifier 1=Enable, 0=Disable
+	AntennaPower bool   `yaml:"antennaPower" json:"antennaPower,omitempty"` // -p antenna_enable Antenna port power, 1=Enable, 0=Disable
 }
 
 func (c *Config) Validate() error {
@@ -115,12 +113,4 @@ func (c *Config) Args() ([]string, error) {
 	}
 
 	return args, nil
-}
-
-func (c *Config) String() string {
-	args, err := c.Args()
-	if err != nil {
-		return fmt.Sprintf("hackrf.Config: failed to build args: %s", err)
-	}
-	return fmt.Sprintf("%s %s", Runtime, strings.Join(args, " "))
 }

--- a/internal/sdr/hackrf/device.go
+++ b/internal/sdr/hackrf/device.go
@@ -16,7 +16,7 @@ const (
 	Device  = "HackRF"
 )
 
-// handler struct represents an RTL-SDR handler
+// handler struct represents a HackRF handler
 type handler struct {
 	binPath string
 	args    []string
@@ -37,10 +37,12 @@ func New(config *Config) (sdr.Handler, error) {
 	return &handler{binPath, args}, nil
 }
 
+// Cmd returns an exec.Cmd configured to run the device's command-line tool
 func (h handler) Cmd(ctx context.Context) *exec.Cmd {
 	return exec.CommandContext(ctx, h.binPath, h.args...)
 }
 
+// Parse processes a single line of output from the device's command-line tool
 func (h handler) Parse(line string, deviceID string, sr chan<- *sdr.SweepResult) error {
 	fields := strings.Split(line, ",")
 	if len(fields) < 7 {
@@ -97,14 +99,19 @@ func (h handler) Parse(line string, deviceID string, sr chan<- *sdr.SweepResult)
 	return nil
 }
 
+// Device returns the identifier or type of the SDR device being handled
 func (h handler) Device() string {
 	return Device
 }
 
+// Runtime returns the name or path of the command-line tool used to
+// control the device (e.g., "rtl_power", "hackrf_sweep")
 func (h handler) Runtime() string {
 	return h.binPath
 }
 
+// Args returns the list of command-line arguments needed to run the
+// device's command-line tool with the desired configuration
 func (h handler) Args() []string {
 	return h.args
 }

--- a/internal/sdr/rtl/config.go
+++ b/internal/sdr/rtl/config.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
-	"strings"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -166,36 +165,36 @@ type Config struct {
 	BinWidth       int64 `yaml:"binWidth" json:"binWidth"`             // -f bin_size Bin size in Hz (valid range 1Hz - 2.8MHz)
 
 	// Common Optional Parameters
-	Interval TimeDuration `yaml:"interval" json:"interval"` // -i integration_interval (default: 10 seconds)
+	Interval TimeDuration `yaml:"interval" json:"interval,omitempty"` // -i integration_interval (default: 10 seconds)
 	// Time units: 's' seconds, 'm' minutes, 'h' hours
 	// Default unit is seconds
 	// Examples: "30s", "15m", "2h"
 
-	DeviceIndex int `yaml:"deviceIndex" json:"deviceIndex"` // -d device_index (default: 0)
+	DeviceIndex int `yaml:"deviceIndex" json:"deviceIndex,omitempty"` // -d device_index (default: 0)
 
-	Gain     int `yaml:"gain" json:"gain"`         // -g tuner_gain (default: automatic)
-	PPMError int `yaml:"ppmError" json:"ppmError"` // -p ppm_error (default: 0)
+	Gain     int `yaml:"gain" json:"gain,omitempty"`         // -g tuner_gain (default: automatic)
+	PPMError int `yaml:"ppmError" json:"ppmError,omitempty"` // -p ppm_error (default: 0)
 
 	// Time Control
-	ExitTimer TimeDuration `yaml:"exitTimer" json:"exitTimer"` // -e exit_timer (default: off/0)
+	ExitTimer TimeDuration `yaml:"exitTimer" json:"exitTimer,omitempty"` // -e exit_timer (default: off/0)
 	// Time units: 's' seconds, 'm' minutes, 'h' hours
 	// Default unit is seconds
 	// Examples: "30s", "15m", "2h"
 
 	// Processing Options
-	Smoothing  SmoothingMethod `yaml:"smoothing" json:"smoothing"`   // -s [avg|iir] Smoothing (default: avg)
-	FFTThreads int             `yaml:"fftThreads" json:"fftThreads"` // -t threads Number of FFT threads
+	Smoothing  SmoothingMethod `yaml:"smoothing" json:"smoothing,omitempty"`   // -s [avg|iir] Smoothing (default: avg)
+	FFTThreads int             `yaml:"fftThreads" json:"fftThreads,omitempty"` // -t threads Number of FFT threads
 
 	// Advanced/Experimental Options
-	WindowFunction WindowFunction `yaml:"windowFunction" json:"windowFunction"` // -w window (default: rectangle)
-	Crop           float32        `yaml:"crop" json:"crop"`                     // -c crop_percent (default: 0%, recommended: 20%-50%)
-	FIRSize        *int           `yaml:"firSize" json:"firSize"`               // -F fir_size (default: disabled, can be 0 or 9)
+	WindowFunction WindowFunction `yaml:"windowFunction" json:"windowFunction,omitempty"` // -w window (default: rectangle)
+	Crop           float32        `yaml:"crop" json:"crop,omitempty"`                     // -c crop_percent (default: 0%, recommended: 20%-50%)
+	FIRSize        *int           `yaml:"firSize" json:"firSize,omitempty"`               // -F fir_size (default: disabled, can be 0 or 9)
 
 	// Hardware Options
-	PeakHold       bool `yaml:"peakHold" json:"peakHold"`             // -P enables peak hold (default: off)
-	DirectSampling bool `yaml:"directSampling" json:"directSampling"` // -D enable direct sampling (default: off)
-	OffsetTuning   bool `yaml:"offsetTuning" json:"offsetTuning"`     // -O enable offset tuning (default: off)
-	BiasTee        bool `yaml:"biasTee" json:"biasTee"`               // -T enable bias-tee (default: off)
+	PeakHold       bool `yaml:"peakHold" json:"peakHold,omitempty"`             // -P enables peak hold (default: off)
+	DirectSampling bool `yaml:"directSampling" json:"directSampling,omitempty"` // -D enable direct sampling (default: off)
+	OffsetTuning   bool `yaml:"offsetTuning" json:"offsetTuning,omitempty"`     // -O enable offset tuning (default: off)
+	BiasTee        bool `yaml:"biasTee" json:"biasTee,omitempty"`               // -T enable bias-tee (default: off)
 }
 
 func (c *Config) Validate() error {
@@ -330,12 +329,4 @@ func (c *Config) Args() ([]string, error) {
 	args = append(args, "-") // Always dump to stdout
 
 	return args, nil
-}
-
-func (c *Config) String() string {
-	args, err := c.Args()
-	if err != nil {
-		return fmt.Sprintf("rtl.Config: failed to build args: %s", err)
-	}
-	return fmt.Sprintf("%s %s", Runtime, strings.Join(args, " "))
 }

--- a/internal/sdr/rtl/device.go
+++ b/internal/sdr/rtl/device.go
@@ -37,10 +37,12 @@ func New(config *Config) (sdr.Handler, error) {
 	return &handler{binPath, args}, nil
 }
 
+// Cmd returns an exec.Cmd configured to run the device's command-line tool
 func (h handler) Cmd(ctx context.Context) *exec.Cmd {
 	return exec.CommandContext(ctx, h.binPath, h.args...)
 }
 
+// Parse processes a single line of output from the device's command-line tool
 func (h handler) Parse(line string, deviceID string, sr chan<- *sdr.SweepResult) error {
 	fields := strings.Split(line, ",")
 	if len(fields) < 7 {
@@ -97,14 +99,19 @@ func (h handler) Parse(line string, deviceID string, sr chan<- *sdr.SweepResult)
 	return nil
 }
 
+// Device returns the identifier or type of the SDR device being handled
 func (h handler) Device() string {
 	return Device
 }
 
+// Runtime returns the name or path of the command-line tool used to
+// control the device (e.g., "rtl_power", "hackrf_sweep")
 func (h handler) Runtime() string {
 	return h.binPath
 }
 
+// Args returns the list of command-line arguments needed to run the
+// device's command-line tool with the desired configuration
 func (h handler) Args() []string {
 	return h.args
 }


### PR DESCRIPTION
<details>
<summary>Details</summary>

#### Description
Replaced struct tags with `omitempty` to streamline JSON and YAML outputs, ensuring optional fields are omitted when empty. Removed unused `String()` methods and redundant `strings` imports in config files. Updated documentation and minor comments for better clarity in device handlers.

#### Changes
- Replaced struct tags with `omitempty`
- Removed unused `String()` methods
- Cleaned up redundant `strings` imports
- Updated documentation and comments
</details>